### PR TITLE
feat: mark internal atoms as private

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "html-webpack-plugin": "^5.5.0",
     "jest": "^29.4.1",
     "jest-environment-jsdom": "^29.4.1",
-    "jotai": "https://pkg.csb.dev/pmndrs/jotai/commit/5e0c7f9e/jotai/_pkg.tgz",
+    "jotai": "^2.0.3",
     "microbundle": "^0.15.1",
     "npm-run-all": "^4.1.5",
     "prettier": "^2.8.3",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "html-webpack-plugin": "^5.5.0",
     "jest": "^29.4.1",
     "jest-environment-jsdom": "^29.4.1",
-    "jotai": "^2.0.0",
+    "jotai": "https://pkg.csb.dev/pmndrs/jotai/commit/5e0c7f9e/jotai/_pkg.tgz",
     "microbundle": "^0.15.1",
     "npm-run-all": "^4.1.5",
     "prettier": "^2.8.3",

--- a/src/atomWithCache.ts
+++ b/src/atomWithCache.ts
@@ -25,7 +25,9 @@ export function atomWithCache<Value>(
   // this cache is common across Provider components
   const cache: [CreatedAt, AnyAtomValue, Map<AnyAtom, AnyAtomValue>][] = [];
   const writeGetterAtom = atom<[Getter] | null>(null);
-  writeGetterAtom.debugPrivate = true;
+  if (process.env.NODE_ENV !== 'production') {
+    writeGetterAtom.debugPrivate = true;
+  }
 
   const baseAtom = atom(
     (get, opts) => {
@@ -71,7 +73,9 @@ export function atomWithCache<Value>(
     },
   );
 
-  baseAtom.debugPrivate = true;
+  if (process.env.NODE_ENV !== 'production') {
+    baseAtom.debugPrivate = true;
+  }
 
   baseAtom.onMount = (init) => {
     init(true);

--- a/src/atomWithCache.ts
+++ b/src/atomWithCache.ts
@@ -25,6 +25,8 @@ export function atomWithCache<Value>(
   // this cache is common across Provider components
   const cache: [CreatedAt, AnyAtomValue, Map<AnyAtom, AnyAtomValue>][] = [];
   const writeGetterAtom = atom<[Getter] | null>(null);
+  writeGetterAtom.debugPrivate = true;
+
   const baseAtom = atom(
     (get, opts) => {
       const writeGetter = get(writeGetterAtom)?.[0];
@@ -68,6 +70,9 @@ export function atomWithCache<Value>(
       }
     },
   );
+
+  baseAtom.debugPrivate = true;
+
   baseAtom.onMount = (init) => {
     init(true);
     return () => init(false);

--- a/yarn.lock
+++ b/yarn.lock
@@ -5013,10 +5013,9 @@ jest@^29.4.1:
     import-local "^3.0.2"
     jest-cli "^29.4.1"
 
-jotai@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/jotai/-/jotai-2.0.0.tgz#3938ad0166130417811bb57ec2de8abeb24bd948"
-  integrity sha512-04G0CRZQgp3xrFAezd6X14psZ2TRGekHeYMBcbDJ/BR8ZJQPS+j0YkMTxUxyG58HJnN2+adfj5sWQWoqgtp1XQ==
+"jotai@https://pkg.csb.dev/pmndrs/jotai/commit/5e0c7f9e/jotai/_pkg.tgz":
+  version "2.0.2"
+  resolved "https://pkg.csb.dev/pmndrs/jotai/commit/5e0c7f9e/jotai/_pkg.tgz#85bdb3e7a19daad7a3cbdc3b12eda7329b733222"
 
 js-sdsl@^4.1.4:
   version "4.3.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5013,9 +5013,10 @@ jest@^29.4.1:
     import-local "^3.0.2"
     jest-cli "^29.4.1"
 
-"jotai@https://pkg.csb.dev/pmndrs/jotai/commit/5e0c7f9e/jotai/_pkg.tgz":
-  version "2.0.2"
-  resolved "https://pkg.csb.dev/pmndrs/jotai/commit/5e0c7f9e/jotai/_pkg.tgz#85bdb3e7a19daad7a3cbdc3b12eda7329b733222"
+jotai@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/jotai/-/jotai-2.0.3.tgz#3b67cda9f6d5feb70a14db0b842a9873aacda8b5"
+  integrity sha512-MMjhSPAL3RoeZD9WbObufRT2quThEAEknHHridf2ma8Ml7ZVQmUiHk0ssdbR3F0h3kcwhYqSGJ59OjhPge7RRg==
 
 js-sdsl@^4.1.4:
   version "4.3.0"


### PR DESCRIPTION
### Checklist 

- [x] Check with Daishi if we should wrap the `debugPrivate` assignment in the dev-only flag now or do it later as it may require tooling changes
- [x] Update the `jotai` version to `2.0.3` once released