### PR TITLE
fix: with latest jotai

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changed
 
 - Module-first setup #11
+- fix: with latest jotai #12
 
 ## [0.4.1] - 2024-01-30
 

--- a/src/atomWithCache.ts
+++ b/src/atomWithCache.ts
@@ -31,6 +31,7 @@ export function atomWithCache<Value>(
     AnyAtomValue
   > = atom(
     async (get, { setSelf: writeGetter, ...opts }): Promise<Awaited<Value>> => {
+      await Promise.resolve();
       const index = cache.findIndex((item) =>
         Array.from(item[2]).every(([a, v]) => is(v, writeGetter(a))),
       );


### PR DESCRIPTION
Not sure when it broke, but we need to await before using `setSelf`. It feels suboptimal and there might be a better way.